### PR TITLE
URL encode parameters in Queryables

### DIFF
--- a/js/lib/queryables.js
+++ b/js/lib/queryables.js
@@ -12,7 +12,9 @@ Queryables = {
 			
 		for(var i = 0; i < str_params.length; i++) {
 			var pair = str_params[i].split('=')
-			params[pair[0]] = pair[1]
+			var key = decodeURIComponent(pair[0])
+			var value = decodeURIComponent(pair[1])
+			params[key] = value
 		}
 		return params
 	},


### PR DESCRIPTION
URL encode each key and value in the query string generated by Queryables
using encodeURIComponent().

The Lindenmayer System Generator was using square brackets in the query
strings, but technically these are invalid in URLs. Previously URLs of
fractals could not be shared Facebook because Facebook will URL encode any
unencoded URLs, breaking the site.

This change should be backwards compatible as long as long as there weren't
already any % symbols in the query string.

The downside of this change is it makes horribly ugly URLs now.

---

I wasn't sure if you wanted a pull request against this repo or [smalljs](https://github.com/NolanDC/smalljs), there's a version of Queryables in that repo too, but [it's not quite the same](https://github.com/NolanDC/smalljs/blob/57afd7a7830e90e5dd6e28e2b41ac12b901e82f3/queryables/queryables.js).

I wanted to share some snowflake fractals on Facebook, but the square brackets and commas weren't surviving the round trip through it. This change adds URL encoding to all keys and values in the query string.
